### PR TITLE
Disabling Java DNS cache for Zookeeper ensemble on docker

### DIFF
--- a/3.4.6/centos/7/Dockerfile
+++ b/3.4.6/centos/7/Dockerfile
@@ -4,6 +4,9 @@ RUN yum install -y java-1.7.0-openjdk-headless tar
 
 RUN curl -fL http://mirror.catn.com/pub/apache/zookeeper/stable/zookeeper-3.4.6.tar.gz | tar xzf - -C /opt && mv /opt/zookeeper-3.4.6 /opt/zookeeper
 
+RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/jre/lib/security/java.security && \
+    sed -i 's/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/g' /usr/lib/jvm/jre/lib/security/java.security
+
 VOLUME /tmp/zookeeper
 
 COPY entrypoint.sh /

--- a/3.4.6/centos/7/Dockerfile
+++ b/3.4.6/centos/7/Dockerfile
@@ -7,6 +7,8 @@ RUN curl -fL http://mirror.catn.com/pub/apache/zookeeper/stable/zookeeper-3.4.6.
 RUN echo "networkaddress.cache.ttl=0" >> /usr/lib/jvm/jre/lib/security/java.security && \
     sed -i 's/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/g' /usr/lib/jvm/jre/lib/security/java.security
 
+EXPOSE 2181 2888 3888
+
 VOLUME /tmp/zookeeper
 
 COPY entrypoint.sh /

--- a/3.4.6/centos/7/entrypoint.sh
+++ b/3.4.6/centos/7/entrypoint.sh
@@ -1,12 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 # based on https://github.com/apache/zookeeper/blob/trunk/conf/zoo_sample.cfg
 cat > /opt/zookeeper/conf/zoo.cfg <<EOF
-tickTime=2000
-initLimit=10
-syncLimit=5
+tickTime=${TICK_TIME:-2000}
+initLimit=${INIT_LIMIT:-10}
+syncLimit=${SYNC_LIMIT:-5}
 dataDir=/tmp/zookeeper
 clientPort=2181
+cnxTimeout=${CNX_TO_MS:-5000}
 EOF
 
 # server.1=...

--- a/3.4.6/ubuntu/14.04/Dockerfile
+++ b/3.4.6/ubuntu/14.04/Dockerfile
@@ -4,6 +4,9 @@ RUN apt-get update && apt-get install -y curl openjdk-7-jre-headless python
 
 RUN curl -fL http://mirror.catn.com/pub/apache/zookeeper/stable/zookeeper-3.4.6.tar.gz | tar xzf - -C /opt && mv /opt/zookeeper-3.4.6 /opt/zookeeper
 
+RUN echo "networkaddress.cache.ttl=0" >> /etc/java-7-openjdk/security/java.security && \
+    sed -i 's/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/g' /etc/java-7-openjdk/security/java.security
+
 VOLUME /tmp/zookeeper
 
 COPY entrypoint.sh /

--- a/3.4.6/ubuntu/14.04/Dockerfile
+++ b/3.4.6/ubuntu/14.04/Dockerfile
@@ -7,6 +7,8 @@ RUN curl -fL http://mirror.catn.com/pub/apache/zookeeper/stable/zookeeper-3.4.6.
 RUN echo "networkaddress.cache.ttl=0" >> /etc/java-7-openjdk/security/java.security && \
     sed -i 's/networkaddress.cache.negative.ttl=10/networkaddress.cache.negative.ttl=0/g' /etc/java-7-openjdk/security/java.security
 
+EXPOSE 2181 2888 3888
+
 VOLUME /tmp/zookeeper
 
 COPY entrypoint.sh /

--- a/3.4.6/ubuntu/14.04/entrypoint.sh
+++ b/3.4.6/ubuntu/14.04/entrypoint.sh
@@ -1,12 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 # based on https://github.com/apache/zookeeper/blob/trunk/conf/zoo_sample.cfg
 cat > /opt/zookeeper/conf/zoo.cfg <<EOF
-tickTime=2000
-initLimit=10
-syncLimit=5
+tickTime=${TICK_TIME:-2000}
+initLimit=${INIT_LIMIT:-10}
+syncLimit=${SYNC_LIMIT:-5}
 dataDir=/tmp/zookeeper
 clientPort=2181
+cnxTimeout=${CNX_TO_MS:-5000}
 EOF
 
 # server.1=...


### PR DESCRIPTION
I'd found an issue when creating a ZK ensemble with 3 ZK containers (by setting `MYID` and `SERVERS`) along with dnsdock.
The issue is the first of the three containers kept failing to resolve other hosts (UnknownHostException was thrown) which started after the first one is running. This was caused by Java's DNS cache preventing the ZK from performing DNS queries, so I disabled it.

After disabling the DNS cache, ZK ensemble on docker worked fine.

Please consider to review and accept this request if the change is helpful for you as well or discard it otherwise.
